### PR TITLE
fix: Clamp spherical calculation to between -1 and 1

### DIFF
--- a/src/Geo.php
+++ b/src/Geo.php
@@ -33,7 +33,7 @@ class Geo
 
 		$theta = $a->lng() - $b->lng();
 		$dist  = sin(deg2rad($a->lat())) * sin(deg2rad($b->lat())) +  cos(deg2rad($a->lat())) * cos(deg2rad($b->lat())) * cos(deg2rad($theta));
-		$dist = min(1, max(-1, $dist));
+		$dist  = min(1, max(-1, $dist));
 		$dist  = acos($dist);
 		$dist  = rad2deg($dist);
 		$miles = $dist * 60 * 1.1515;

--- a/src/Geo.php
+++ b/src/Geo.php
@@ -33,6 +33,7 @@ class Geo
 
 		$theta = $a->lng() - $b->lng();
 		$dist  = sin(deg2rad($a->lat())) * sin(deg2rad($b->lat())) +  cos(deg2rad($a->lat())) * cos(deg2rad($b->lat())) * cos(deg2rad($theta));
+		$dist = min(1, max(-1, $dist));
 		$dist  = acos($dist);
 		$dist  = rad2deg($dist);
 		$miles = $dist * 60 * 1.1515;

--- a/tests/GeoTest.php
+++ b/tests/GeoTest.php
@@ -14,12 +14,12 @@ class GeoTest extends TestCase
 
 		$this->assertSame(464.15696938977845, $distance);
 	}
-	public function testDistanceDoesNotReturnNaN(): void
+
+	public function testDistanceSameHighPrecisionPoint(): void
 	{
 		$castle = Geo::point(50.706914865043444, -1.549996006816997);
 		$distance = Geo::distance($castle, $castle);
 
-		$this->assertIsFloat($distance);
 		$this->assertSame(0.0, $distance);
 	}
 

--- a/tests/GeoTest.php
+++ b/tests/GeoTest.php
@@ -14,6 +14,14 @@ class GeoTest extends TestCase
 
 		$this->assertSame(464.15696938977845, $distance);
 	}
+	public function testDistanceDoesNotReturnNaN(): void
+	{
+		$castle = Geo::point(50.706914865043444, -1.549996006816997);
+		$distance = Geo::distance($castle, $castle);
+
+		$this->assertIsFloat($distance);
+		$this->assertSame(0.0, $distance);
+	}
 
 	public function testDistanceInMiles(): void
 	{


### PR DESCRIPTION
## Description
Fixes #7 by clamping the result of spherical calculation to between -1 and 1 to prevent floating point rounding error

### Reasoning
Discussed in the description of #7  



